### PR TITLE
#1 Add optional price in products

### DIFF
--- a/app/src/main/java/pl/jergro/shopinglist/ui/views/ProductView.kt
+++ b/app/src/main/java/pl/jergro/shopinglist/ui/views/ProductView.kt
@@ -3,6 +3,7 @@ package pl.jergro.shopinglist.ui.views
 import android.content.Context
 import android.content.res.ColorStateList
 import android.view.LayoutInflater
+import android.view.View
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import androidx.databinding.DataBindingUtil
@@ -73,5 +74,11 @@ class ProductView(context: Context) : ConstraintLayout(context) {
                 else R.color.md_grey_900
             ))
         )
+
+        if (product.price != 0.0) {
+            binding.productPriceText.visibility = View.VISIBLE
+        } else {
+            binding.productPriceText.visibility = View.GONE
+        }
     }
 }


### PR DESCRIPTION
hiding the price view, when it's 0

![hide_no_price](https://user-images.githubusercontent.com/42608330/60532566-f1300780-9cd3-11e9-8500-10bd3bff9eef.png)
